### PR TITLE
fix(Tooltip): fix arrow style when without reset.css

### DIFF
--- a/src/components/Tooltip/__test__/__snapshots__/demo.test.js.snap
+++ b/src/components/Tooltip/__test__/__snapshots__/demo.test.js.snap
@@ -164,6 +164,7 @@ exports[`Tooltip demo -- placement 1`] = `
   position: absolute;
   width: 0;
   height: 0;
+  border-width: 0;
   border-color: transparent;
   border-style: solid;
 }
@@ -173,6 +174,7 @@ exports[`Tooltip demo -- placement 1`] = `
   position: absolute;
   width: 0;
   height: 0;
+  border-width: 0;
   border-color: transparent;
   border-style: solid;
 }
@@ -1148,6 +1150,7 @@ exports[`Tooltip demo -- theme 1`] = `
   position: absolute;
   width: 0;
   height: 0;
+  border-width: 0;
   border-color: transparent;
   border-style: solid;
 }
@@ -1157,6 +1160,7 @@ exports[`Tooltip demo -- theme 1`] = `
   position: absolute;
   width: 0;
   height: 0;
+  border-width: 0;
   border-color: transparent;
   border-style: solid;
 }

--- a/src/components/Tooltip/style/index.js
+++ b/src/components/Tooltip/style/index.js
@@ -25,6 +25,7 @@ const arrowMixin = css`
     position: absolute;
     width: 0;
     height: 0;
+    border-width: 0;
     border-color: transparent;
     border-style: solid;
 `;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
bug fix

**What is the current behavior? (You can also link to an open issue here)**
#5 

**What is the new behavior (if this is a feature change)?**
Set arrow default border to none for fix style bug

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**

*   [X] Follow our contributing docs
*   [ ] Docs have been added/updated
*   [X] Tests have been added; existing tests pass

**Other information**:
close #5