### PR TITLE
chore(Develop): remove jest all demo in precommit hooks

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -5,8 +5,7 @@
         "stylelint './src/style/*.js'",
         "stylelint './src/components/**/*.(jsx|js)'",
         "eslint",
-        "jest --bail --findRelatedTests",
-        "jest --bail --all --testPathPattern=demo.test.js"
+        "jest --bail --findRelatedTests"
     ],
     "*.{json,css,md}": ["prettier --write", "git add"]
 }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Optimize develop 

**What is the current behavior? (You can also link to an open issue here)**
Need to run all demo test in precommit

**What is the new behavior (if this is a feature change)?**
Remove jest test all demo to speed up precommit

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**

*   [X] Follow our contributing docs
*   [ ] Docs have been added/updated
*   [ ] Tests have been added; existing tests pass

**Other information**:
