### PR TITLE
feat(NumberInput): trigger onNumberChange when press enter

### DIFF
--- a/src/components/NumberInput/NumberInput.jsx
+++ b/src/components/NumberInput/NumberInput.jsx
@@ -48,6 +48,8 @@ class NumberInput extends Component {
         onKeyDown: PropTypes.func,
         /** @ignore */
         onKeyUp: PropTypes.func,
+        /** @ignore */
+        onEnter: PropTypes.func,
         /** 禁用 */
         disabled: PropTypes.bool,
         /** @ignore */
@@ -97,6 +99,7 @@ class NumberInput extends Component {
         onChange: noop,
         onNumberChange: noop,
         onKeyDown: noop,
+        onEnter: noop,
         onFocus: noop,
         onBlur: noop,
         parser: defaultParser,
@@ -185,6 +188,8 @@ class NumberInput extends Component {
             const ratio = this.getRatio(e);
             this.down(e, ratio);
             this.stop();
+        } else if (e.keyCode === KEYCODE['ENTER']) {
+            this.onEnter(e, ...args);
         }
         const { onKeyDown } = this.props;
         if (onKeyDown) {
@@ -225,6 +230,18 @@ class NumberInput extends Component {
         e.persist(); // fix https://github.com/react-component/input-number/issues/51
         this.setValue(value, () => {
             this.props.onBlur(e, ...args);
+            this.props.onNumberChange(value);
+        });
+    };
+
+    onEnter = (e, ...args) => {
+        const value = this.getCurrentValidValue(this.state.inputValue);
+        if (e) {
+            e.persist();
+            e.preventDefault();
+        }
+        this.setValue(value, () => {
+            this.props.onEnter(e, ...args);
             this.props.onNumberChange(value);
         });
     };

--- a/src/components/NumberInput/__tests__/index.test.js
+++ b/src/components/NumberInput/__tests__/index.test.js
@@ -81,6 +81,11 @@ describe('NumberInput', () => {
         expect(onNumberChange).toHaveBeenCalledTimes(++onNumberChangeCallTimes);
         expect(onNumberChange).toHaveBeenLastCalledWith(0);
 
+        input.simulate('keydown', { keyCode: KeyCode['ENTER'] });
+        input.simulate('keyup', { keyCode: KeyCode['ENTER'] });
+        expect(onNumberChange).toHaveBeenCalledTimes(++onNumberChangeCallTimes);
+        expect(onNumberChange).toHaveBeenLastCalledWith(0);
+
         input.simulate('blur');
     });
 });


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
feature
**What is the current behavior? (You can also link to an open issue here)**
no effect when press enter
**What is the new behavior (if this is a feature change)?**
add onEnter prop
trigger onNumberChange when press enter key
**Does this PR introduce a breaking change?**
No
**Please check if the PR fulfills these requirements**

*   [X] Follow our contributing docs
*   [X] Docs have been added/updated
*   [X] Tests have been added; existing tests pass

**Other information**:
