### PR TITLE
fix(Slider): fix numberinput value translate bug

### DIFF
--- a/src/components/NumberInput/NumberInput.jsx
+++ b/src/components/NumberInput/NumberInput.jsx
@@ -40,7 +40,7 @@ class NumberInput extends Component {
         /** 修改回调 */
         onChange: PropTypes.func,
         /**
-         * 有效的修改回调，使用按钮改变值或者输入后失焦时触发，可防止监听到无效的回调
+         * 有效的修改回调，使用按钮改变值或者输入、回车后失焦时触发，可防止监听到无效的回调
          * @param value - 当前的值，必为有效数字
          */
         onNumberChange: PropTypes.func,
@@ -64,6 +64,10 @@ class NumberInput extends Component {
         min: PropTypes.number,
         /** 按钮每次变动大小 */
         step: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+        /** @ignore */
+        upStep: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+        /** @ignore */
+        downStep: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
         /** 自定义'+'按钮 */
         upHandler: PropTypes.node,
         /** 自定义'-'按钮 */
@@ -411,9 +415,12 @@ class NumberInput extends Component {
     }
 
     upStep(val, rat) {
-        const { step, min } = this.props;
+        let { step, upStep, min } = this.props;
         const precisionFactor = this.getPrecisionFactor(val, rat);
         const precision = Math.abs(this.getMaxPrecision(val, rat));
+        if (upStep != null) {
+            step = upStep;
+        }
         let result;
         if (typeof val === 'number') {
             result = ((precisionFactor * val + precisionFactor * step * rat) / precisionFactor).toFixed(precision);
@@ -424,9 +431,12 @@ class NumberInput extends Component {
     }
 
     downStep(val, rat) {
-        const { step, min } = this.props;
+        let { step, downStep, min } = this.props;
         const precisionFactor = this.getPrecisionFactor(val, rat);
         const precision = Math.abs(this.getMaxPrecision(val, rat));
+        if (downStep != null) {
+            step = downStep;
+        }
         let result;
         if (typeof val === 'number') {
             result = ((precisionFactor * val - precisionFactor * step * rat) / precisionFactor).toFixed(precision);

--- a/src/components/NumberInput/__tests__/index.test.js
+++ b/src/components/NumberInput/__tests__/index.test.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { renderToJson } from 'enzyme-to-json';
 
 import NumberInput from 'src/components/NumberInput';
 import KeyCode from 'src/interfaces/KeyCode';
@@ -11,6 +10,7 @@ describe('NumberInput', () => {
         const onNumberChange = jest.fn();
         const onFocus = jest.fn();
         const onBlur = jest.fn();
+        const onEnter = jest.fn();
 
         let onNumberChangeCallTimes = 0;
 
@@ -21,6 +21,7 @@ describe('NumberInput', () => {
                 onNumberChange={onNumberChange}
                 onFocus={onFocus}
                 onBlur={onBlur}
+                onEnter={onEnter}
             />
         );
 
@@ -48,9 +49,11 @@ describe('NumberInput', () => {
 
         const input = wrapper.find('input');
         input.simulate('focus');
-        input.simulate('change', 'aaa');
+        input.simulate('change', { target: { value: 'aaa' } });
+        expect(onChange).toHaveBeenLastCalledWith('aaa');
         input.simulate('blur');
-
+        expect(onChange).toHaveBeenLastCalledWith(0);
+        expect(onChange).toHaveBeenCalledTimes(4);
         expect(onFocus).toHaveBeenCalledTimes(1);
         expect(onBlur).toHaveBeenCalledTimes(1);
         expect(onNumberChange).toHaveBeenCalledTimes(++onNumberChangeCallTimes);
@@ -86,6 +89,21 @@ describe('NumberInput', () => {
         expect(onNumberChange).toHaveBeenCalledTimes(++onNumberChangeCallTimes);
         expect(onNumberChange).toHaveBeenLastCalledWith(0);
 
+        input.simulate('change', { target: { value: 'aaa' } });
+        expect(onChange).toHaveBeenLastCalledWith('aaa');
         input.simulate('blur');
+        expect(onNumberChange).toHaveBeenCalledTimes(++onNumberChangeCallTimes);
+        expect(onNumberChange).toHaveBeenLastCalledWith(0);
+
+        input.simulate('focus');
+        input.simulate('change', { target: { value: 'aaa' } });
+        expect(onChange).toHaveBeenLastCalledWith('aaa');
+        input.simulate('keydown', { keyCode: KeyCode['ENTER'] });
+        input.simulate('keyup', { keyCode: KeyCode['ENTER'] });
+        expect(onNumberChange).toHaveBeenCalledTimes(++onNumberChangeCallTimes);
+        expect(onNumberChange).toHaveBeenLastCalledWith(0);
+        input.simulate('blur');
+
+        expect(onEnter).toHaveBeenCalledTimes(2);
     });
 });

--- a/src/components/Slider/__tests__/index.test.js
+++ b/src/components/Slider/__tests__/index.test.js
@@ -2,12 +2,26 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import Slider from 'src/components/Slider';
+import KeyCode from 'src/interfaces/KeyCode';
 
 jest.unmock('rc-trigger');
 
 describe('Slider', () => {
+    test('float', () => {
+        const onChange = jest.fn();
+        let onChangeCalledTimes = 0;
+        const wrapper = mount(<Slider min={0} max={100} step={0.1} onChange={onChange} />);
+        const input = wrapper.find('input');
+
+        input.simulate('focus');
+        input.simulate('change', { target: { value: '4.11111111' } });
+        input.simulate('blur');
+        expect(onChange).toHaveBeenCalledTimes(++onChangeCalledTimes);
+        expect(onChange).toHaveBeenCalledWith(4.1);
+    });
     test('marks', () => {
         const onChange = jest.fn();
+        let onChangeCalledTimes = 0;
         const wrapper = mount(
             <Slider
                 min={10}
@@ -62,6 +76,7 @@ describe('Slider', () => {
             target: slider.getDOMNode()
         });
         slider.simulate('mouseup');
+        expect(onChange).toHaveBeenCalledTimes(++onChangeCalledTimes);
         expect(onChange).toHaveBeenLastCalledWith(24);
         slider.simulate('mousedown', {
             type: 'mousedown',
@@ -72,6 +87,7 @@ describe('Slider', () => {
             target: slider.getDOMNode()
         });
         slider.simulate('mouseup');
+        expect(onChange).toHaveBeenCalledTimes(++onChangeCalledTimes);
         expect(onChange).toHaveBeenLastCalledWith(1000);
         slider.simulate('mousedown', {
             type: 'mousedown',
@@ -82,6 +98,7 @@ describe('Slider', () => {
             target: slider.getDOMNode()
         });
         slider.simulate('mouseup');
+        expect(onChange).toHaveBeenCalledTimes(++onChangeCalledTimes);
         expect(onChange).toHaveBeenLastCalledWith(100);
         slider.simulate('mousedown', {
             type: 'mousedown',
@@ -93,7 +110,7 @@ describe('Slider', () => {
         });
         slider.simulate('mouseup');
         expect(onChange).toHaveBeenLastCalledWith(24);
-        expect(onChange).toHaveBeenCalledTimes(4);
+        expect(onChange).toHaveBeenCalledTimes(++onChangeCalledTimes);
 
         wrapper.setProps({
             value: 10
@@ -108,10 +125,36 @@ describe('Slider', () => {
         });
         expect(sliderHandler.instance().style.left).toBe('100%');
 
+        const input = wrapper.find('input');
+
+        expect(input.length).toBe(1);
+        input.simulate('change', { target: { value: '123' } });
+        expect(onChange).toHaveBeenCalledTimes(onChangeCalledTimes);
+        input.simulate('keydown', { keyCode: KeyCode['ENTER'] });
+        expect(onChange).toHaveBeenCalledTimes(++onChangeCalledTimes);
+        expect(onChange).toHaveBeenLastCalledWith(120);
+
+        input.simulate('change', { target: { value: '1001' } });
+        expect(onChange).toHaveBeenCalledTimes(onChangeCalledTimes);
+        input.simulate('keydown', { keyCode: KeyCode['ENTER'] });
+        expect(onChange).toHaveBeenCalledTimes(++onChangeCalledTimes);
+        expect(onChange).toHaveBeenLastCalledWith(1000);
+
+        input.simulate('change', { target: { value: '1000' } });
+        expect(onChange).toHaveBeenCalledTimes(onChangeCalledTimes);
+        input.simulate('keydown', { keyCode: KeyCode['ENTER'] });
+        expect(onChange).toHaveBeenCalledTimes(++onChangeCalledTimes);
+        expect(onChange).toHaveBeenLastCalledWith(1000);
+
+        input.simulate('change', { target: { value: '123' } });
+        expect(onChange).toHaveBeenCalledTimes(onChangeCalledTimes);
+        input.simulate('keydown', { keyCode: KeyCode['ENTER'] });
+        expect(onChange).toHaveBeenCalledTimes(++onChangeCalledTimes);
+        expect(onChange).toHaveBeenLastCalledWith(120);
+
         wrapper.setProps({
             marks: {}
         });
-
         slider.simulate('mousedown', {
             type: 'mousedown',
             pageX: 60,
@@ -122,6 +165,18 @@ describe('Slider', () => {
         });
         slider.simulate('mouseup');
         expect(onChange).toHaveBeenLastCalledWith((1000 - 10) / 5 + 10);
-        expect(onChange).toHaveBeenCalledTimes(5);
+        expect(onChange).toHaveBeenCalledTimes(++onChangeCalledTimes);
+
+        input.simulate('change', { target: { value: '1001' } });
+        expect(onChange).toHaveBeenCalledTimes(onChangeCalledTimes);
+        input.simulate('keydown', { keyCode: KeyCode['ENTER'] });
+        expect(onChange).toHaveBeenCalledTimes(++onChangeCalledTimes);
+        expect(onChange).toHaveBeenLastCalledWith(1000);
+
+        input.simulate('change', { target: { value: '123' } });
+        expect(onChange).toHaveBeenCalledTimes(onChangeCalledTimes);
+        input.simulate('keydown', { keyCode: KeyCode['ENTER'] });
+        expect(onChange).toHaveBeenCalledTimes(++onChangeCalledTimes);
+        expect(onChange).toHaveBeenLastCalledWith(123);
     });
 });


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
bug fix
**What is the current behavior? (You can also link to an open issue here)**
float compute is wrong
numberInput change did not compute right value
**What is the new behavior (if this is a feature change)?**
when get value from numberInput, translate value to right.
fix compute wrong float value bug
**Does this PR introduce a breaking change?**
No
**Please check if the PR fulfills these requirements**

*   [X] Follow our contributing docs
*   [ ] Docs have been added/updated
*   [X] Tests have been added; existing tests pass

**Other information**:
