### PR TITLE
fix(Table): hide tip wrap when emptyContent is null

### DIFF
--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -609,7 +609,7 @@ class Table extends Component {
                 </div>
             );
         }
-        if (!dataSource || !dataSource.length) {
+        if ((!dataSource || !dataSource.length) && emptyContent) {
             return (
                 <div key="tip-info" className={`${prefixCls}-tip-wrap`}>
                     <div className={`${prefixCls}-empty-content-wrap`}>{emptyContent}</div>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
bug fix
**What is the current behavior? (You can also link to an open issue here)**
when emptyContent is null, tip wrap is displayed, and the style is strange.
**What is the new behavior (if this is a feature change)?**

**Does this PR introduce a breaking change?**

**Please check if the PR fulfills these requirements**

*   [X] Follow our contributing docs
*   [ ] Docs have been added/updated
*   [X] Tests have been added; existing tests pass

**Other information**:
