### PR TITLE
fix(Table): fix when table hideExpandIcon. width is not wrong

### DIFF
--- a/src/components/Table/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/components/Table/__tests__/__snapshots__/demo.test.js.snap
@@ -29925,6 +29925,7 @@ exports[`Table demo -- hideExpandIcon 1`] = `
 
 .c0 .uc-fe-table-row-expand-icon-cell,
 .c0 .uc-fe-table-expand-icon-th,
+.c0 .uc-fe-table-expand-icon-col,
 .c0 .uc-fe-table-expanded-row > td:first-child {
   display: none;
 }

--- a/src/components/Table/style/index.js
+++ b/src/components/Table/style/index.js
@@ -110,6 +110,7 @@ export const TableWrap = styled.div`
             css`
                 &-row-expand-icon-cell,
                 &-expand-icon-th,
+                &-expand-icon-col,
                 &-expanded-row > td:first-child {
                     display: none;
                 }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
bug fix 
**What is the current behavior? (You can also link to an open issue here)**
when table hideExpandIcon. width is not wrong
**What is the new behavior (if this is a feature change)?**

**Does this PR introduce a breaking change?**

**Please check if the PR fulfills these requirements**

*   [X] Follow our contributing docs
*   [ ] Docs have been added/updated
*   [X] Tests have been added; existing tests pass

**Other information**:
