### PR TITLE
feat(DatePicker): add getCalendarContainer to set popover container

### DIFF
--- a/src/components/DatePicker/DatePicker.jsx
+++ b/src/components/DatePicker/DatePicker.jsx
@@ -55,12 +55,15 @@ class DatePicker extends Component {
         /** 是否禁用 */
         disabled: PropTypes.bool,
         /** 弹出层的z-index */
-        zIndex: PropTypes.number
+        zIndex: PropTypes.number,
+        /** 弹出层容器，参考popover.getPopupContainer */
+        getCalendarContainer: PropTypes.func
     };
     static defaultProps = {
         onChange: () => {},
         size: 'md',
-        zIndex: 100
+        zIndex: 100,
+        getCalendarContainer: triggerNode => triggerNode.parentNode
     };
     componentWillReceiveProps = nextProps => {
         if ('value' in nextProps) {
@@ -154,8 +157,18 @@ class DatePicker extends Component {
         return <TimeWrap>{picker}</TimeWrap>;
     };
     render() {
-        // eslint-disable-next-line no-unused-vars
-        const { rules, value: _v, defaultValue, display = {}, size, onChange, zIndex, ...rest } = this.props;
+        const {
+            rules,
+            value: _v,
+            // eslint-disable-next-line no-unused-vars
+            defaultValue,
+            display = {},
+            size,
+            onChange,
+            zIndex,
+            getCalendarContainer,
+            ...rest
+        } = this.props;
         const { date = {} } = display;
         const value = moment(_v);
 
@@ -166,7 +179,7 @@ class DatePicker extends Component {
                         prefixCls={pickerPrefixCls}
                         transitionName={`${animationPrefixCls}-fade`}
                         calendar={<Calendar rules={rules} />}
-                        getCalendarContainer={triggerNode => triggerNode.parentNode}
+                        getCalendarContainer={getCalendarContainer}
                         value={value}
                         align={placements.bottomLeft}
                         onChange={onChange}

--- a/src/components/DatePicker/DatePicker.md
+++ b/src/components/DatePicker/DatePicker.md
@@ -33,3 +33,8 @@
 
 ```js {"codepath": "datepicker-uncontrolled.jsx"}
 ```
+
+*   getCalendarContainer
+
+```js {"codepath": "datepicker-getcalendarcontainer.jsx"}
+```

--- a/src/components/DatePicker/Month.jsx
+++ b/src/components/DatePicker/Month.jsx
@@ -40,12 +40,15 @@ class Month extends Component {
         /** 是否禁用 */
         disabled: PropTypes.bool,
         /** 弹出层的z-index */
-        zIndex: PropTypes.number
+        zIndex: PropTypes.number,
+        /** 弹出层容器，参考popover.getPopupContainer */
+        getCalendarContainer: PropTypes.func
     };
     static defaultProps = {
         onChange: () => {},
         size: 'md',
-        zIndex: 100
+        zIndex: 100,
+        getCalendarContainer: triggerNode => triggerNode.parentNode
     };
     componentWillReceiveProps = nextProps => {
         if ('value' in nextProps) {
@@ -88,8 +91,18 @@ class Month extends Component {
         }
     };
     render() {
-        // eslint-disable-next-line no-unused-vars
-        const { rules, value: _v, defaultValue, size, display = {}, onChange, zIndex, ...rest } = this.props;
+        const {
+            rules,
+            value: _v,
+            // eslint-disable-next-line no-unused-vars
+            defaultValue,
+            size,
+            display = {},
+            onChange,
+            zIndex,
+            getCalendarContainer,
+            ...rest
+        } = this.props;
         const { date = {} } = display;
         const value = moment(_v);
 
@@ -99,7 +112,7 @@ class Month extends Component {
                     prefixCls={monthPickerPrefixCls}
                     transitionName={`${animationPrefixCls}-fade`}
                     calendar={<MonthCalendar rules={rules} />}
-                    getCalendarContainer={triggerNode => triggerNode.parentNode}
+                    getCalendarContainer={getCalendarContainer}
                     value={value}
                     align={placements.bottomLeft}
                     onChange={onChange}

--- a/src/components/DatePicker/Month.md
+++ b/src/components/DatePicker/Month.md
@@ -33,3 +33,8 @@
 
 ```js {"codepath": "month-uncontrolled.jsx"}
 ```
+
+*   getCalendarContainer
+
+```js {"codepath": "month-getcalendarcontainer.jsx"}
+```

--- a/src/components/DatePicker/Range.jsx
+++ b/src/components/DatePicker/Range.jsx
@@ -83,6 +83,12 @@ class Range extends Component {
         disabled: PropTypes.bool,
         /** 弹出层的z-index */
         zIndex: PropTypes.number,
+        /** 自定义默认选项props */
+        selectProps: PropTypes.object,
+        /** 自定义时间选择框弹出层props */
+        popoverProps: PropTypes.object,
+        /** 自定义datepicker的props */
+        datePickerProps: PropTypes.object,
         /** @ignore */
         locale: PropTypes.object
     };
@@ -93,6 +99,9 @@ class Range extends Component {
         options: [],
         defaultOption: 'custom',
         onOptionChange: () => {},
+        selectProps: {},
+        popoverProps: {},
+        datePickerProps: {},
         size: 'md',
         zIndex: 100
     };
@@ -173,6 +182,9 @@ class Range extends Component {
             disabled,
             zIndex,
             locale,
+            selectProps,
+            datePickerProps,
+            popoverProps,
             ...rest
         } = this.props;
         /* eslint-enable no-unused-vars */
@@ -207,7 +219,7 @@ class Range extends Component {
                         value={option}
                         disabled={disabled}
                         onChange={this.handleOptionChange}
-                        popover={{ zIndex }}
+                        popoverProps={{ zIndex, ...selectProps.popoverProps }}
                     />
                 )}
                 <Popover
@@ -256,6 +268,7 @@ class Range extends Component {
                     }
                     onVisibleChange={this.handleVisibleChange}
                     trigger={['click']}
+                    {..._.pick(popoverProps, ['getPopupContainer'])}
                 >
                     <RangeDateWrap size={size} readonly={readonly} disabled={disabled}>
                         <span>{start.format(rangeFormat || formatString[type])}</span>

--- a/src/components/DatePicker/Range.md
+++ b/src/components/DatePicker/Range.md
@@ -53,3 +53,8 @@
 
 ```js {"codepath": "range-uncontrolled.jsx"}
 ```
+
+*   popoverProps
+
+```js {"codepath": "range-popoverprops.jsx"}
+```

--- a/src/components/DatePicker/__demo__/datepicker-getcalendarcontainer.jsx
+++ b/src/components/DatePicker/__demo__/datepicker-getcalendarcontainer.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import DatePicker from 'src/components/DatePicker';
+import Modal from 'src/components/Modal';
+import Button from 'src/components/Button';
+
+// demo start
+const Demo = () => (
+    <div>
+        <div className="demo-wrap">
+            <Button
+                onClick={() => {
+                    Modal.confirm(
+                        {
+                            title: 'datePicker'
+                        },
+                        <div style={{ padding: 24 }}>
+                            <DatePicker onChange={v => console.log(v.format())} />
+                        </div>
+                    );
+                }}
+            >
+                default
+            </Button>
+            <Button
+                onClick={() => {
+                    Modal.confirm(
+                        {
+                            title: 'datePicker'
+                        },
+                        <div style={{ padding: 24, position: 'relative', overflow: 'auto' }}>
+                            <DatePicker onChange={v => console.log(v.format())} />
+                        </div>
+                    );
+                }}
+            >
+                wrong display with positioned wrap
+            </Button>
+            <Button
+                onClick={() => {
+                    Modal.confirm(
+                        {
+                            title: 'datePicker'
+                        },
+                        <div style={{ padding: 24, position: 'relative', overflow: 'auto' }}>
+                            <DatePicker
+                                onChange={v => console.log(v.format())}
+                                getCalendarContainer={() => document.body}
+                                zIndex={1020}
+                            />
+                        </div>
+                    );
+                }}
+            >
+                place calendar into body
+            </Button>
+        </div>
+    </div>
+);
+// demo end
+
+export default Demo;

--- a/src/components/DatePicker/__demo__/month-getcalendarcontainer.jsx
+++ b/src/components/DatePicker/__demo__/month-getcalendarcontainer.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import DatePicker from 'src/components/DatePicker';
+import Modal from 'src/components/Modal';
+import Button from 'src/components/Button';
+
+// demo start
+const Demo = () => (
+    <div>
+        <div className="demo-wrap">
+            <Button
+                onClick={() => {
+                    Modal.confirm(
+                        {
+                            title: 'datePicker'
+                        },
+                        <div style={{ padding: 24 }}>
+                            <DatePicker.Month onChange={v => console.log(v.format())} />
+                        </div>
+                    );
+                }}
+            >
+                default
+            </Button>
+            <Button
+                onClick={() => {
+                    Modal.confirm(
+                        {
+                            title: 'datePicker'
+                        },
+                        <div style={{ padding: 24, position: 'relative', overflow: 'auto' }}>
+                            <DatePicker.Month onChange={v => console.log(v.format())} />
+                        </div>
+                    );
+                }}
+            >
+                wrong display with positioned wrap
+            </Button>
+            <Button
+                onClick={() => {
+                    Modal.confirm(
+                        {
+                            title: 'datePicker'
+                        },
+                        <div style={{ padding: 24, position: 'relative', overflow: 'auto' }}>
+                            <DatePicker.Month
+                                onChange={v => console.log(v.format())}
+                                getCalendarContainer={() => document.body}
+                                zIndex={1020}
+                            />
+                        </div>
+                    );
+                }}
+            >
+                place calendar into body
+            </Button>
+        </div>
+    </div>
+);
+// demo end
+
+export default Demo;

--- a/src/components/DatePicker/__demo__/range-popoverprops.jsx
+++ b/src/components/DatePicker/__demo__/range-popoverprops.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import DatePicker from 'src/components/DatePicker';
+import Modal from 'src/components/Modal';
+import Button from 'src/components/Button';
+
+// demo start
+const Demo = () => (
+    <div>
+        <div className="demo-wrap">
+            <Button
+                onClick={() => {
+                    Modal.confirm(
+                        {
+                            title: 'datePicker range',
+                            size: 'md'
+                        },
+                        <div style={{ padding: 24 }}>
+                            <DatePicker.Range onChange={console.log} />
+                        </div>
+                    );
+                }}
+            >
+                default
+            </Button>
+            <Button
+                onClick={() => {
+                    Modal.confirm(
+                        {
+                            title: 'datePicker range',
+                            size: 'md'
+                        },
+                        <div style={{ padding: 24, position: 'relative', overflow: 'auto' }}>
+                            <DatePicker.Range onChange={console.log} />
+                        </div>
+                    );
+                }}
+            >
+                wrong display with positioned wrap
+            </Button>
+            <Button
+                onClick={() => {
+                    Modal.confirm(
+                        {
+                            title: 'datePicker range',
+                            size: 'md'
+                        },
+                        <div style={{ padding: 24, position: 'relative', overflow: 'auto' }}>
+                            <DatePicker.Range
+                                onChange={console.log}
+                                popoverProps={{
+                                    getPopupContainer: () => document.body
+                                }}
+                                selectProps={{
+                                    popoverProps: {
+                                        getPopupContainer: () => document.body
+                                    }
+                                }}
+                                zIndex={1020}
+                            />
+                        </div>
+                    );
+                }}
+            >
+                place popover into body
+            </Button>
+        </div>
+    </div>
+);
+// demo end
+
+export default Demo;

--- a/src/components/DatePicker/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/components/DatePicker/__tests__/__snapshots__/demo.test.js.snap
@@ -1802,6 +1802,59 @@ exports[`DatePicker demo -- datepicker-display 1`] = `
 </div>
 `;
 
+exports[`DatePicker demo -- datepicker-getcalendarcontainer 1`] = `
+.c0 {
+  box-sizing: border-box;
+  border-radius: 2px;
+  border-width: 1px;
+  border-style: solid;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  outline: none;
+  font-size: 12px;
+  display: inline-block;
+  vertical-align: middle;
+  height: 28px;
+  padding: 0 8px;
+  color: #6b798e;
+  background: #fff;
+  border-color: #c3cad9;
+}
+
+.c0:hover {
+  color: #4074e1;
+  background: #fff;
+  border-color: #4683e6;
+}
+
+<div>
+  <div
+    class="demo-wrap"
+  >
+    <button
+      class="uc-fe-button uc-fe-button-size-md uc-fe-button-styletype-border c0"
+      type="button"
+    >
+      default
+    </button>
+    <button
+      class="uc-fe-button uc-fe-button-size-md uc-fe-button-styletype-border c0"
+      type="button"
+    >
+      wrong display with positioned wrap
+    </button>
+    <button
+      class="uc-fe-button uc-fe-button-size-md uc-fe-button-styletype-border c0"
+      type="button"
+    >
+      place calendar into body
+    </button>
+  </div>
+</div>
+`;
+
 exports[`DatePicker demo -- datepicker-rules 1`] = `
 .c7 {
   position: relative;
@@ -3803,6 +3856,59 @@ exports[`DatePicker demo -- month-display 1`] = `
 </div>
 `;
 
+exports[`DatePicker demo -- month-getcalendarcontainer 1`] = `
+.c0 {
+  box-sizing: border-box;
+  border-radius: 2px;
+  border-width: 1px;
+  border-style: solid;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  outline: none;
+  font-size: 12px;
+  display: inline-block;
+  vertical-align: middle;
+  height: 28px;
+  padding: 0 8px;
+  color: #6b798e;
+  background: #fff;
+  border-color: #c3cad9;
+}
+
+.c0:hover {
+  color: #4074e1;
+  background: #fff;
+  border-color: #4683e6;
+}
+
+<div>
+  <div
+    class="demo-wrap"
+  >
+    <button
+      class="uc-fe-button uc-fe-button-size-md uc-fe-button-styletype-border c0"
+      type="button"
+    >
+      default
+    </button>
+    <button
+      class="uc-fe-button uc-fe-button-size-md uc-fe-button-styletype-border c0"
+      type="button"
+    >
+      wrong display with positioned wrap
+    </button>
+    <button
+      class="uc-fe-button uc-fe-button-size-md uc-fe-button-styletype-border c0"
+      type="button"
+    >
+      place calendar into body
+    </button>
+  </div>
+</div>
+`;
+
 exports[`DatePicker demo -- month-rules 1`] = `
 .c2 {
   height: 28px;
@@ -5477,6 +5583,59 @@ exports[`DatePicker demo -- range-options 1`] = `
         />
       </div>
     </div>
+  </div>
+</div>
+`;
+
+exports[`DatePicker demo -- range-popoverprops 1`] = `
+.c0 {
+  box-sizing: border-box;
+  border-radius: 2px;
+  border-width: 1px;
+  border-style: solid;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  outline: none;
+  font-size: 12px;
+  display: inline-block;
+  vertical-align: middle;
+  height: 28px;
+  padding: 0 8px;
+  color: #6b798e;
+  background: #fff;
+  border-color: #c3cad9;
+}
+
+.c0:hover {
+  color: #4074e1;
+  background: #fff;
+  border-color: #4683e6;
+}
+
+<div>
+  <div
+    class="demo-wrap"
+  >
+    <button
+      class="uc-fe-button uc-fe-button-size-md uc-fe-button-styletype-border c0"
+      type="button"
+    >
+      default
+    </button>
+    <button
+      class="uc-fe-button uc-fe-button-size-md uc-fe-button-styletype-border c0"
+      type="button"
+    >
+      wrong display with positioned wrap
+    </button>
+    <button
+      class="uc-fe-button uc-fe-button-size-md uc-fe-button-styletype-border c0"
+      type="button"
+    >
+      place popover into body
+    </button>
   </div>
 </div>
 `;

--- a/src/components/LocaleProvider/__demo__/list.jsx
+++ b/src/components/LocaleProvider/__demo__/list.jsx
@@ -59,7 +59,7 @@ class Demo extends Component {
             width: 100,
             filter: {
                 options: [1, 2],
-                popover: { getPopupContainer: () => document.body }
+                popoverProps: { getPopupContainer: () => document.body }
             },
             render: record => <span>content {record.index}</span>
         }));

--- a/src/components/Pagination/Options.jsx
+++ b/src/components/Pagination/Options.jsx
@@ -93,7 +93,7 @@ class Options extends React.Component {
                     value={pageSize.toString()}
                     onChange={this.changeSize}
                     size={size}
-                    popover={{ getPopupContainer: triggerNode => triggerNode.parentNode }}
+                    popoverProps={{ getPopupContainer: triggerNode => triggerNode.parentNode }}
                     {...select}
                 >
                     {options}

--- a/src/components/Pagination/__tests__/index.test.js
+++ b/src/components/Pagination/__tests__/index.test.js
@@ -96,7 +96,7 @@ describe('Pagination', () => {
                 showSizeChanger
                 onPageSizeChange={onPageSizeChange}
                 total={100}
-                optionsProps={{ select: { popover: { getPopupContainer: () => document.body } } }}
+                optionsProps={{ select: { popoverProps: { getPopupContainer: () => document.body } } }}
             />
         );
 

--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -7,6 +7,7 @@ import Popover from 'src/components/Popover';
 import uncontrolledDecorator from 'decorators/uncontrolled';
 import localeConsumerDecorator from 'src/components/LocaleProvider/localeConsumerDecorator';
 import { getItemTree, rootPrefix } from 'src/components/Menu/Menu';
+import deprecatedLog from 'src/utils/deprecatedLog';
 
 import Option from './Option';
 import { SelectWrap, SelectSearchInput, Selector, Arrow, BlockMenu, MenuWrap } from './style';
@@ -33,6 +34,9 @@ class Select extends Component {
             searchValue: '',
             itemTree
         };
+        if ('popover' in props) {
+            deprecatedLog('popover', 'popoverProps');
+        }
     }
     static propTypes = {
         /** @ignore */
@@ -81,8 +85,13 @@ class Select extends Component {
         ]),
         /** 尺寸 */
         size: PropTypes.oneOf(Size),
-        /** 弹出层的popover props */
+        /**
+         * 弹出层的popover props
+         * @deprecated 请使用popoverProps替换
+         */
         popover: PropTypes.object,
+        /** 弹出层的popover props */
+        popoverProps: PropTypes.object,
         /** @ignore */
         onVisibleChange: PropTypes.func,
         /** @ignore */
@@ -256,6 +265,7 @@ class Select extends Component {
             renderContent,
             renderSelector,
             popover,
+            popoverProps,
             ...rest
         } = this.props;
         /* eslint-enable no-unused-vars */
@@ -277,6 +287,7 @@ class Select extends Component {
                         getPopupContainer={triggerNode => triggerNode.parentNode}
                         visible={visible}
                         {...popover}
+                        {...popoverProps}
                     >
                         <div>{this.renderSelector()}</div>
                     </Popover>

--- a/src/components/Select/Select.md
+++ b/src/components/Select/Select.md
@@ -49,7 +49,7 @@
 ```js {"codepath": "showSelectAll.jsx"}
 ```
 
-*   popover - 弹出层的 popover props
+*   popoverProps - 弹出层的 popover props
 
-```js {"codepath": "popover.jsx"}
+```js {"codepath": "popoverProps.jsx"}
 ```

--- a/src/components/Select/__demo__/popoverProps.jsx
+++ b/src/components/Select/__demo__/popoverProps.jsx
@@ -11,7 +11,7 @@ class Demo extends React.Component {
             <div>
                 {animations.map(animation => (
                     <div className="demo-wrap" key={animation}>
-                        <Select defaultValue={1} popover={{ animation }}>
+                        <Select defaultValue={1} popoverProps={{ animation }}>
                             <Option value={1}>1</Option>
                             <Option value={2}>2</Option>
                             <Option value={3}>3</Option>

--- a/src/components/Select/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/components/Select/__tests__/__snapshots__/demo.test.js.snap
@@ -259,7 +259,7 @@ exports[`Select demo -- multiple 1`] = `
 </div>
 `;
 
-exports[`Select demo -- popover 1`] = `
+exports[`Select demo -- popoverProps 1`] = `
 .c2 {
   border-radius: 2px;
   cursor: pointer;

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -302,7 +302,7 @@ class Table extends Component {
                 renderSelector={(content, visible) => {
                     return <Icon key="icon" type="filter" size="xs" color={visible ? 'blue' : null} />;
                 }}
-                popover={{ getPopupContainer: () => this.popupContainer }}
+                popoverProps={{ getPopupContainer: () => this.popupContainer }}
                 multiple={multiple}
                 {...rest}
             />

--- a/src/components/ThemeProvider/__demo__/themeprovider.jsx
+++ b/src/components/ThemeProvider/__demo__/themeprovider.jsx
@@ -23,7 +23,7 @@ const columns = new Array(5).fill(null).map((v, i) => ({
     width: 100,
     filter: {
         options: [1, 2],
-        popover: { getPopupContainer: () => document.body }
+        popoverProps: { getPopupContainer: () => document.body }
     },
     render: function Column(record) {
         return <span>content {record.index}</span>;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
feature
**What is the current behavior? (You can also link to an open issue here)**

**What is the new behavior (if this is a feature change)?**
add DatePicker.getCalendarContainer to set popover container
add DatePicker.Range.popoverProps to set popover props
rename Select.popover to popoverProps
**Does this PR introduce a breaking change?**
No
**Please check if the PR fulfills these requirements**

*   [X] Follow our contributing docs
*   [X] Docs have been added/updated
*   [X] Tests have been added; existing tests pass

**Other information**:
