### PR TITLE
fix(Slider): ZForm dec bug & style bug

### DIFF
--- a/src/components/Badge/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/components/Badge/__tests__/__snapshots__/demo.test.js.snap
@@ -116,7 +116,6 @@ exports[`Badge demo -- badge 1`] = `
 
 .c24 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 

--- a/src/components/Button/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/components/Button/__tests__/__snapshots__/demo.test.js.snap
@@ -121,7 +121,6 @@ exports[`Button demo -- button 1`] = `
 
 .c6 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 

--- a/src/components/Checkbox/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/components/Checkbox/__tests__/__snapshots__/demo.test.js.snap
@@ -34,7 +34,6 @@ exports[`Checkbox demo -- checkbox 1`] = `
 
 .c6 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 
@@ -1138,7 +1137,6 @@ exports[`Checkbox demo -- group 1`] = `
 
 .c6 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 

--- a/src/components/Compact/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/components/Compact/__tests__/__snapshots__/demo.test.js.snap
@@ -3,7 +3,6 @@
 exports[`Compact demo -- compact 1`] = `
 .c22 {
   position: relative;
-  z-index: 1;
   margin-left: 1px;
 }
 
@@ -54,7 +53,6 @@ exports[`Compact demo -- compact 1`] = `
 
 .c6 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 
@@ -465,7 +463,6 @@ exports[`Compact demo -- compact 1`] = `
 exports[`Compact demo -- sharedProps 1`] = `
 .c0 {
   position: relative;
-  z-index: 1;
   margin-left: 1px;
 }
 

--- a/src/components/Compact/style/index.js
+++ b/src/components/Compact/style/index.js
@@ -11,7 +11,6 @@ export const CompactWrap = styled.div.attrs({
     className: prefixCls
 })`
     position: relative;
-    z-index: 1;
     margin-left: 1px;
 
     .${controllerPrefix} {

--- a/src/components/DatePicker/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/components/DatePicker/__tests__/__snapshots__/demo.test.js.snap
@@ -252,7 +252,6 @@ exports[`DatePicker demo -- datepicker 1`] = `
 
 .c18 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 
@@ -3215,7 +3214,6 @@ exports[`DatePicker demo -- month 1`] = `
 
 .c17 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 
@@ -4213,7 +4211,6 @@ exports[`DatePicker demo -- range 1`] = `
 
 .c6 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 

--- a/src/components/Form/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/components/Form/__tests__/__snapshots__/demo.test.js.snap
@@ -614,7 +614,7 @@ exports[`Form demo -- group 1`] = `
   border: 1px solid #c3cad9;
   background: #fff;
   touch-action: pan-x;
-  z-index: 1;
+  z-index: 9;
   height: 34px;
   line-height: 36px;
 }

--- a/src/components/Grid/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/components/Grid/__tests__/__snapshots__/demo.test.js.snap
@@ -1475,7 +1475,6 @@ exports[`Grid demo -- row 1`] = `
 
 .c16 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 

--- a/src/components/Icon/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/components/Icon/__tests__/__snapshots__/demo.test.js.snap
@@ -110,7 +110,6 @@ exports[`Icon demo -- icon 1`] = `
 
 .c6 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 

--- a/src/components/Input/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/demo.test.js.snap
@@ -122,7 +122,6 @@ exports[`Input demo -- input 1`] = `
 
 .c6 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 
@@ -1105,7 +1104,6 @@ exports[`Input demo -- search 1`] = `
 
 .c6 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 

--- a/src/components/LocaleProvider/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/components/LocaleProvider/__tests__/__snapshots__/demo.test.js.snap
@@ -782,7 +782,6 @@ exports[`LocaleProvider demo -- list 1`] = `
 
 .c6 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 
@@ -1670,7 +1669,7 @@ exports[`LocaleProvider demo -- list 1`] = `
   border: 1px solid #c3cad9;
   background: #fff;
   touch-action: pan-x;
-  z-index: 1;
+  z-index: 9;
   height: 34px;
   line-height: 36px;
 }

--- a/src/components/LocaleProvider/__tests__/__snapshots__/index.test.js.snap
+++ b/src/components/LocaleProvider/__tests__/__snapshots__/index.test.js.snap
@@ -10,7 +10,7 @@ exports[`LocaleProvider Modal 4`] = `"<div tabindex=\\"-1\\" class=\\"uc-fe-moda
 
 exports[`LocaleProvider Slider 1`] = `
 <div
-  class="test-slider style__SliderWrap-sc-1rsqtg6-0 bYnTRF"
+  class="test-slider style__SliderWrap-sc-1rsqtg6-0 hVucPM"
 >
   <div
     class="uc-fe-slider"
@@ -109,7 +109,7 @@ exports[`LocaleProvider Slider 1`] = `
 
 exports[`LocaleProvider Slider 2`] = `
 <div
-  class="test-slider-sensitive style__SliderWrap-sc-1rsqtg6-0 bYnTRF"
+  class="test-slider-sensitive style__SliderWrap-sc-1rsqtg6-0 hVucPM"
 >
   <div
     class="uc-fe-slider"
@@ -208,7 +208,7 @@ exports[`LocaleProvider Slider 2`] = `
 
 exports[`LocaleProvider Slider 3`] = `
 <div
-  class="test-slider style__SliderWrap-sc-1rsqtg6-0 bYnTRF"
+  class="test-slider style__SliderWrap-sc-1rsqtg6-0 hVucPM"
 >
   <div
     class="uc-fe-slider"
@@ -307,7 +307,7 @@ exports[`LocaleProvider Slider 3`] = `
 
 exports[`LocaleProvider Slider 4`] = `
 <div
-  class="test-slider-sensitive style__SliderWrap-sc-1rsqtg6-0 bYnTRF"
+  class="test-slider-sensitive style__SliderWrap-sc-1rsqtg6-0 hVucPM"
 >
   <div
     class="uc-fe-slider"
@@ -511,7 +511,7 @@ exports[`LocaleProvider switch locale 1`] = `
         span="9"
       >
         <div
-          class="style__RadioGroupWrap-sc-25j3mq-9 iXBRFs"
+          class="style__RadioGroupWrap-sc-25j3mq-9 gACTQh"
         >
           <button
             class="style__RadioButtonWrap-sc-25j3mq-2 uc-fe-radio uc-fe-radio-checked uc-fe-radio-size-md uc-fe-radio-styletype-button jOYUYC sc-bdVaJa uc-fe-button uc-fe-button-size-md uc-fe-button-styletype-border gtCmIJ"
@@ -2315,7 +2315,7 @@ exports[`LocaleProvider switch locale 1`] = `
           style="margin-bottom: 10px;"
         >
           <div
-            class="test-slider style__SliderWrap-sc-1rsqtg6-0 bYnTRF"
+            class="test-slider style__SliderWrap-sc-1rsqtg6-0 hVucPM"
           >
             <div
               class="uc-fe-slider"
@@ -2385,7 +2385,7 @@ exports[`LocaleProvider switch locale 1`] = `
         </div>
         <div>
           <div
-            class="test-slider-sensitive style__SliderWrap-sc-1rsqtg6-0 bYnTRF"
+            class="test-slider-sensitive style__SliderWrap-sc-1rsqtg6-0 hVucPM"
           >
             <div
               class="uc-fe-slider"
@@ -2480,7 +2480,7 @@ exports[`LocaleProvider switch locale 2`] = `
         span="9"
       >
         <div
-          class="style__RadioGroupWrap-sc-25j3mq-9 iXBRFs"
+          class="style__RadioGroupWrap-sc-25j3mq-9 gACTQh"
         >
           <button
             class="style__RadioButtonWrap-sc-25j3mq-2 uc-fe-radio uc-fe-radio-size-md uc-fe-radio-styletype-button bPFQDA sc-bdVaJa uc-fe-button uc-fe-button-size-md uc-fe-button-styletype-border gtCmIJ"
@@ -4284,7 +4284,7 @@ exports[`LocaleProvider switch locale 2`] = `
           style="margin-bottom: 10px;"
         >
           <div
-            class="test-slider style__SliderWrap-sc-1rsqtg6-0 bYnTRF"
+            class="test-slider style__SliderWrap-sc-1rsqtg6-0 hVucPM"
           >
             <div
               class="uc-fe-slider"
@@ -4354,7 +4354,7 @@ exports[`LocaleProvider switch locale 2`] = `
         </div>
         <div>
           <div
-            class="test-slider-sensitive style__SliderWrap-sc-1rsqtg6-0 bYnTRF"
+            class="test-slider-sensitive style__SliderWrap-sc-1rsqtg6-0 hVucPM"
           >
             <div
               class="uc-fe-slider"

--- a/src/components/Modal/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/components/Modal/__tests__/__snapshots__/demo.test.js.snap
@@ -398,7 +398,6 @@ exports[`Modal demo -- modal 1`] = `
 
 .c6 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 

--- a/src/components/Notice/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/components/Notice/__tests__/__snapshots__/demo.test.js.snap
@@ -594,7 +594,6 @@ exports[`Notice demo -- notice 1`] = `
 
 .c6 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 

--- a/src/components/NumberInput/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/components/NumberInput/__tests__/__snapshots__/demo.test.js.snap
@@ -2241,7 +2241,6 @@ exports[`NumberInput demo -- numberInput 1`] = `
 
 .c6 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 

--- a/src/components/Pagination/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/components/Pagination/__tests__/__snapshots__/demo.test.js.snap
@@ -799,7 +799,6 @@ exports[`Pagination demo -- pagination 1`] = `
 
 .c6 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 

--- a/src/components/Radio/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/components/Radio/__tests__/__snapshots__/demo.test.js.snap
@@ -38,7 +38,6 @@ exports[`Radio demo -- group 1`] = `
 
 .c6 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 
@@ -499,7 +498,6 @@ exports[`Radio demo -- group-disabled 1`] = `
 
 .c0 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 
@@ -633,7 +631,6 @@ exports[`Radio demo -- group-options 1`] = `
 
 .c0 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 
@@ -834,7 +831,6 @@ exports[`Radio demo -- group-size 1`] = `
 
 .c0 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 
@@ -1062,7 +1058,6 @@ exports[`Radio demo -- group-styleType 1`] = `
 
 .c0 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 
@@ -1263,7 +1258,6 @@ exports[`Radio demo -- group-uncontrolled 1`] = `
 
 .c0 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 
@@ -1408,7 +1402,6 @@ exports[`Radio demo -- radio 1`] = `
 
 .c6 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 

--- a/src/components/Radio/style/index.js
+++ b/src/components/Radio/style/index.js
@@ -243,7 +243,6 @@ export const RadioCardWrap = styled.div.attrs({
 
 export const RadioGroupWrap = styled.div`
     position: relative;
-    z-index: 1;
     margin-bottom: -8px;
     ${RadioWrap}, ${/* sc-sel */ RadioTagWrap}, ${RadioCardWrap} {
         margin-right: 8px;

--- a/src/components/Select/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/components/Select/__tests__/__snapshots__/demo.test.js.snap
@@ -684,7 +684,6 @@ exports[`Select demo -- select 1`] = `
 
 .c6 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 

--- a/src/components/Slider/Slider.jsx
+++ b/src/components/Slider/Slider.jsx
@@ -20,7 +20,7 @@ const handle = props => {
     return (
         <Tooltip
             popupClassName={`${prefixCls}-tooltip`}
-            popup={_.isFunction(tipFormatter) ? tipFormatter(value) : value}
+            popup={_.isFunction(tipFormatter) ? tipFormatter(value) : value == null ? '' : value}
             visible={dragging && tipFormatter !== null}
             placement="top"
             key={index}
@@ -306,7 +306,9 @@ class Slider extends Component {
         const { marks } = this.state;
         const { min, max } = this.props;
         let value;
-        if (_.isEmpty(marks)) {
+        if (v == undefined) {
+            value = 0;
+        } else if (_.isEmpty(marks)) {
             value = (v - min) / (max - min) * sliderSplit;
         } else if (v == max) {
             value = sliderSplit;

--- a/src/components/Slider/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/components/Slider/__tests__/__snapshots__/demo.test.js.snap
@@ -236,7 +236,7 @@ exports[`Slider demo -- disabled 1`] = `
   border: 1px solid #c3cad9;
   background: #fff;
   touch-action: pan-x;
-  z-index: 1;
+  z-index: 9;
   height: 34px;
   line-height: 36px;
 }
@@ -660,7 +660,7 @@ exports[`Slider demo -- isSensitive 1`] = `
   border: 1px solid #c3cad9;
   background: #fff;
   touch-action: pan-x;
-  z-index: 1;
+  z-index: 9;
   height: 34px;
   line-height: 36px;
 }
@@ -1081,7 +1081,7 @@ exports[`Slider demo -- marks 1`] = `
   border: 1px solid #c3cad9;
   background: #fff;
   touch-action: pan-x;
-  z-index: 1;
+  z-index: 9;
   height: 34px;
   line-height: 36px;
 }
@@ -1657,7 +1657,7 @@ exports[`Slider demo -- minmax 1`] = `
   border: 1px solid #c3cad9;
   background: #fff;
   touch-action: pan-x;
-  z-index: 1;
+  z-index: 9;
   height: 34px;
   line-height: 36px;
 }
@@ -2149,7 +2149,7 @@ exports[`Slider demo -- numberInput 1`] = `
   border: 1px solid #c3cad9;
   background: #fff;
   touch-action: pan-x;
-  z-index: 1;
+  z-index: 9;
   height: 34px;
   line-height: 36px;
 }
@@ -2605,7 +2605,7 @@ exports[`Slider demo -- numberInputTipFormatter 1`] = `
   border: 1px solid #c3cad9;
   background: #fff;
   touch-action: pan-x;
-  z-index: 1;
+  z-index: 9;
   height: 34px;
   line-height: 36px;
 }
@@ -3026,7 +3026,7 @@ exports[`Slider demo -- slider 1`] = `
   border: 1px solid #c3cad9;
   background: #fff;
   touch-action: pan-x;
-  z-index: 1;
+  z-index: 9;
   height: 34px;
   line-height: 36px;
 }
@@ -3134,7 +3134,6 @@ exports[`Slider demo -- slider 1`] = `
 
 .c6 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 
@@ -3922,7 +3921,7 @@ exports[`Slider demo -- step 1`] = `
   border: 1px solid #c3cad9;
   background: #fff;
   touch-action: pan-x;
-  z-index: 1;
+  z-index: 9;
   height: 34px;
   line-height: 36px;
 }
@@ -4343,7 +4342,7 @@ exports[`Slider demo -- tipFormatter 1`] = `
   border: 1px solid #c3cad9;
   background: #fff;
   touch-action: pan-x;
-  z-index: 1;
+  z-index: 9;
   height: 34px;
   line-height: 36px;
 }
@@ -4764,7 +4763,7 @@ exports[`Slider demo -- uncontrolled 1`] = `
   border: 1px solid #c3cad9;
   background: #fff;
   touch-action: pan-x;
-  z-index: 1;
+  z-index: 9;
   height: 34px;
   line-height: 36px;
 }

--- a/src/components/Slider/__tests__/__snapshots__/index.test.js.snap
+++ b/src/components/Slider/__tests__/__snapshots__/index.test.js.snap
@@ -144,7 +144,7 @@ exports[`Slider number input 25`] = `"input:  dsadas --, after press enter, valu
 
 exports[`Slider numberInputTipFormatter 1`] = `
 <div
-  class="style__SliderWrap-sc-1rsqtg6-0 bYnTRF"
+  class="style__SliderWrap-sc-1rsqtg6-0 hVucPM"
 >
   <div
     class="uc-fe-slider"
@@ -215,7 +215,7 @@ exports[`Slider numberInputTipFormatter 1`] = `
 
 exports[`Slider numberInputTipFormatter 2`] = `
 <div
-  class="style__SliderWrap-sc-1rsqtg6-0 bYnTRF"
+  class="style__SliderWrap-sc-1rsqtg6-0 hVucPM"
 >
   <div
     class="uc-fe-slider"
@@ -314,7 +314,7 @@ exports[`Slider numberInputTipFormatter 2`] = `
 
 exports[`Slider numberInputTipFormatter 3`] = `
 <div
-  class="style__SliderWrap-sc-1rsqtg6-0 bYnTRF"
+  class="style__SliderWrap-sc-1rsqtg6-0 hVucPM"
 >
   <div
     class="uc-fe-slider"
@@ -413,7 +413,7 @@ exports[`Slider numberInputTipFormatter 3`] = `
 
 exports[`Slider numberInputTipFormatter 4`] = `
 <div
-  class="style__SliderWrap-sc-1rsqtg6-0 bYnTRF"
+  class="style__SliderWrap-sc-1rsqtg6-0 hVucPM"
 >
   <div
     class="uc-fe-slider"
@@ -519,7 +519,7 @@ exports[`Slider numberInputTipFormatter 4`] = `
 
 exports[`Slider numberInputTipFormatter 5`] = `
 <div
-  class="style__SliderWrap-sc-1rsqtg6-0 bYnTRF"
+  class="style__SliderWrap-sc-1rsqtg6-0 hVucPM"
 >
   <div
     class="uc-fe-slider"
@@ -626,7 +626,7 @@ exports[`Slider numberInputTipFormatter 5`] = `
 
 exports[`Slider numberInputTipFormatter 6`] = `
 <div
-  class="style__SliderWrap-sc-1rsqtg6-0 bYnTRF"
+  class="style__SliderWrap-sc-1rsqtg6-0 hVucPM"
 >
   <div
     class="uc-fe-slider"

--- a/src/components/Slider/style/index.js
+++ b/src/components/Slider/style/index.js
@@ -67,7 +67,7 @@ export const SliderWrap = styled.div(
                 border: 1px solid #c3cad9;
                 background: ${colorMap.default.background};
                 touch-action: pan-x;
-                z-index: 1;
+                z-index: 9;
                 height: ${HeightNumber[size] + 6}px;
                 line-height: ${HeightNumber[size] + 8}px;
 

--- a/src/components/Switch/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/components/Switch/__tests__/__snapshots__/demo.test.js.snap
@@ -1500,7 +1500,6 @@ exports[`Switch demo -- switch 1`] = `
 
 .c6 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 

--- a/src/components/Table/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/components/Table/__tests__/__snapshots__/demo.test.js.snap
@@ -247,7 +247,6 @@ exports[`Table demo -- actionList 1`] = `
 
 .c6 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 

--- a/src/components/Tabs/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/components/Tabs/__tests__/__snapshots__/demo.test.js.snap
@@ -1921,7 +1921,6 @@ exports[`Tabs demo -- tabs 1`] = `
 
 .c6 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 

--- a/src/components/Tooltip/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/components/Tooltip/__tests__/__snapshots__/demo.test.js.snap
@@ -1623,7 +1623,6 @@ exports[`Tooltip demo -- tooltip 1`] = `
 
 .c6 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 

--- a/src/components/ZForm/ZForm.md
+++ b/src/components/ZForm/ZForm.md
@@ -46,6 +46,26 @@
     </ZForm>;
     ```
 
+*   controllerDecorator 包裹的控件为 controlled 状态，value 和 onChange 被 form 托管，组件内定义的默认值将无法生效，如一些控件依赖默认值（如 Slider、Input）必须要注意默认值的传入
+
+    ```js static
+    class Input extends React.Component {
+        render() {
+            return <input {...this.props} />;
+        }
+    }
+    const ZInput = controllerDecorator({
+        // 不传会导致uncontrolled变换为controlled告警
+        initialValue: ''
+    })(Input);
+
+    <ZForm form={form}>
+        <Item>
+            <ZInput zName="input" />
+        </Item>
+    </ZForm>;
+    ```
+
 *   controllerDecorator 支持传入 option
 
     *   valuePropName - 组件的值的 prop 名称

--- a/src/components/ZForm/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/components/ZForm/__tests__/__snapshots__/demo.test.js.snap
@@ -782,7 +782,6 @@ exports[`ZForm demo -- uhost 1`] = `
 
 .c6 {
   position: relative;
-  z-index: 1;
   margin-bottom: -8px;
 }
 


### PR DESCRIPTION
fix #83

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
bug fix
**What is the current behavior? (You can also link to an open issue here)**

**What is the new behavior (if this is a feature change)?**
when use in ZForm without initialValue, will crash for value of undefined
add zIndex to Slider popover to fix style

**Does this PR introduce a breaking change?**

**Please check if the PR fulfills these requirements**

*   [X] Follow our contributing docs
*   [ ] Docs have been added/updated
*   [X] Tests have been added; existing tests pass

**Other information**:
