### PR TITLE
fix(NumberInput): fix when onHandle return 2 arguments

### DIFF
--- a/src/components/NumberInput/NumberInput.jsx
+++ b/src/components/NumberInput/NumberInput.jsx
@@ -521,14 +521,14 @@ class NumberInput extends Component {
         let downEvents;
 
         upEvents = {
-            onMouseDown: editable && !upDisabled ? this.up : noop,
-            onMouseUp: this.stop,
-            onMouseLeave: this.stop
+            onMouseDown: e => (editable && !upDisabled ? this.up(e) : noop()),
+            onMouseUp: e => this.stop(e),
+            onMouseLeave: e => this.stop(e)
         };
         downEvents = {
-            onMouseDown: editable && !downDisabled ? this.down : noop,
-            onMouseUp: this.stop,
-            onMouseLeave: this.stop
+            onMouseDown: e => (editable && !downDisabled ? this.down(e) : noop()),
+            onMouseUp: e => this.stop(e),
+            onMouseLeave: e => this.stop(e)
         };
 
         return (


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
bug fix
**What is the current behavior? (You can also link to an open issue here)**
if event listener return 2 arguments, click handle will crash
**What is the new behavior (if this is a feature change)?**

**Does this PR introduce a breaking change?**

**Please check if the PR fulfills these requirements**

*   [X] Follow our contributing docs
*   [ ] Docs have been added/updated
*   [X] Tests have been added; existing tests pass

**Other information**:
