### PR TITLE
Menu: add warning if child is not MenuItem or SubMenu component

### DIFF
--- a/src/components/Menu/Menu.jsx
+++ b/src/components/Menu/Menu.jsx
@@ -242,6 +242,8 @@ class Menu extends Component {
                         renderChildren: children => this.renderChildren(children, uid),
                         className
                     });
+                } else {
+                    console.error('Warning: Menu has a child which is not a MenuItem component or SubMenu component');
                 }
 
                 return child;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

**What is the current behavior? (You can also link to an open issue here)**

**What is the new behavior (if this is a feature change)?**

**Does this PR introduce a breaking change?**

**Please check if the PR fulfills these requirements**

*   [x] Follow our contributing docs
*   [ ] Docs have been added/updated
*   [ ] Tests have been added; existing tests pass

**Other information**:
