### PR TITLE
fix(DatePicker): fix onChange returns an unexpected null value

### DIFF
--- a/src/components/DatePicker/Range.tsx
+++ b/src/components/DatePicker/Range.tsx
@@ -269,12 +269,13 @@ const Range = ({
             } else {
                 onChange(newValue);
             }
-            setCacheValue(newValue);
+            setCacheValue(formatRangeValue(newValue, nullable, d));
         },
-        [cacheValue, rules, precision, isFirstEditing, locale, onChange]
+        [cacheValue, rules, precision, isFirstEditing, locale, onChange, nullable, d]
     );
     const handleEndChange = useCallback(
         (value: Moment | null, isClear?: boolean) => {
+            debugger;
             const [valueS] = cacheValue;
             const newValue: CallbackRangeValue = [valueS, value];
             const rangeDateValidResult = isRangeDateValid(newValue, rules, precision);
@@ -296,9 +297,9 @@ const Range = ({
             } else {
                 onChange(newValue);
             }
-            setCacheValue(newValue);
+            setCacheValue(formatRangeValue(newValue, nullable, d));
         },
-        [cacheValue, rules, precision, isFirstEditing, locale, onChange]
+        [cacheValue, rules, precision, isFirstEditing, locale, onChange, nullable, d]
     );
 
     const onClearS = useCallback(() => {

--- a/src/components/DatePicker/Range.tsx
+++ b/src/components/DatePicker/Range.tsx
@@ -275,7 +275,6 @@ const Range = ({
     );
     const handleEndChange = useCallback(
         (value: Moment | null, isClear?: boolean) => {
-            debugger;
             const [valueS] = cacheValue;
             const newValue: CallbackRangeValue = [valueS, value];
             const rangeDateValidResult = isRangeDateValid(newValue, rules, precision);


### PR DESCRIPTION
When the Range is in an error status, if the input is clicked to set a new value, that will cause the onChange function returns an unexpected null value
